### PR TITLE
fix!: use pointers for Tag returns

### DIFF
--- a/pkg/commits_between_test.go
+++ b/pkg/commits_between_test.go
@@ -1,7 +1,6 @@
 package history
 
 import (
-	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,17 +16,15 @@ func TestCommitsBetween(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	tagHash, err := testGit.PreviousTag(head.Hash())
+	tag, err := testGit.PreviousTag(head.Hash())
 
 	assert.NoError(t, err)
 
-	log.Print(tagHash)
-
-	commit, err := repo.CommitObject(tagHash)
+	commit, err := repo.CommitObject(tag.Hash)
 	assert.NoError(t, err)
 	assert.Equal(t, "chore: first commit on master\n", commit.Message)
 
-	commits, err := testGit.CommitsBetween(head.Hash(), tagHash)
+	commits, err := testGit.CommitsBetween(head.Hash(), tag.Hash)
 
 	assert.NoError(t, err)
 	assert.Len(t, commits, 3)

--- a/pkg/current_tag.go
+++ b/pkg/current_tag.go
@@ -34,7 +34,7 @@ func (g *Git) CurrentTag() (*Tag, error) {
 		}
 
 		if tag.Hash == head.Hash() {
-			return &tag, nil
+			return tag, nil
 		}
 	}
 

--- a/pkg/get_tags.go
+++ b/pkg/get_tags.go
@@ -8,7 +8,7 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing"
 )
 
-func (g *Git) getTags() ([]Tag, error) {
+func (g *Git) getTags() ([]*Tag, error) {
 	tagrefs, err := g.repo.Tags()
 
 	if err != nil {
@@ -17,7 +17,7 @@ func (g *Git) getTags() ([]Tag, error) {
 
 	defer tagrefs.Close()
 
-	var tags []Tag
+	var tags []*Tag
 
 	err = tagrefs.ForEach(func(t *plumbing.Reference) error {
 		commitDate, err := g.commitDate(t.Hash())
@@ -26,7 +26,7 @@ func (g *Git) getTags() ([]Tag, error) {
 			return err
 		}
 
-		tags = append(tags, Tag{Name: t.Name().String(), Date: commitDate, Hash: t.Hash()})
+		tags = append(tags, &Tag{Name: t.Name().String(), Date: commitDate, Hash: t.Hash()})
 		return nil
 	})
 
@@ -48,7 +48,7 @@ func (g *Git) getTags() ([]Tag, error) {
 }
 
 // sortTags sorts the tags according to when their parent commit happened.
-func sortTags(repo *git.Repository, tags []Tag) []Tag {
+func sortTags(repo *git.Repository, tags []*Tag) []*Tag {
 	sort.Slice(tags, func(i, j int) bool {
 		return tags[i].Date.After(tags[j].Date)
 	})

--- a/pkg/previous_tag.go
+++ b/pkg/previous_tag.go
@@ -14,14 +14,14 @@ var (
 
 // PreviousTag sorts tags based on when their commit happened and returns the one previous
 // to the current.
-func (g *Git) PreviousTag(currentHash plumbing.Hash) (plumbing.Hash, error) {
+func (g *Git) PreviousTag(currentHash plumbing.Hash) (*Tag, error) {
 	tags, err := g.getTags()
 
 	if err != nil {
 		if g.Debug {
 			log.Printf("[ERR] getting previous tag failed: %v", err)
 		}
-		return currentHash, err
+		return nil, err
 	}
 
 	// If there are fewer than two tags assume that the currentCommit is the newest tag
@@ -29,19 +29,19 @@ func (g *Git) PreviousTag(currentHash plumbing.Hash) (plumbing.Hash, error) {
 		if g.Debug {
 			log.Println("[ERR] previous tag not available")
 		}
-		return currentHash, ErrPrevTagNotAvailable
+		return nil, ErrPrevTagNotAvailable
 	}
 
 	if tags[0].Hash != currentHash {
 		if g.Debug {
 			log.Println("[ERR] current commit does not have a tag attached, building from this commit")
 		}
-		return tags[0].Hash, nil
+		return tags[0], nil
 	}
 
 	if g.Debug {
 		log.Printf("success: previous tag found at %v", tags[1].Hash)
 	}
 
-	return tags[1].Hash, nil
+	return tags[1], nil
 }

--- a/pkg/previous_tag_test.go
+++ b/pkg/previous_tag_test.go
@@ -1,7 +1,6 @@
 package history
 
 import (
-	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,13 +15,11 @@ func TestPreviousTag(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	tagHash, err := testGit.PreviousTag(head.Hash())
+	tag, err := testGit.PreviousTag(head.Hash())
 
 	assert.NoError(t, err)
 
-	log.Print(tagHash)
-
-	commit, err := repo.CommitObject(tagHash)
+	commit, err := repo.CommitObject(tag.Hash)
 	assert.NoError(t, err)
 	assert.Equal(t, "chore: first commit on master\n", commit.Message)
 


### PR DESCRIPTION
BREAKING CHANGE: PreviousTag will now return a pointer to a tag instead of the Hash