### PR TITLE
fix(getTags): wrong hash in annotated tags

### DIFF
--- a/pkg/current_tag_test.go
+++ b/pkg/current_tag_test.go
@@ -19,6 +19,18 @@ func TestCurrentTagHappy(t *testing.T) {
 	assert.Equal(t, "refs/tags/v0.0.2", tag.Name)
 }
 
+func TestCurrentTagAnnotatedHappy(t *testing.T) {
+	repo, err := git.PlainOpen("../testdata/annotated_git_tags_mix")
+	testGit := &Git{repo: repo, Debug: true}
+
+	assert.NoError(t, err)
+
+	tag, err := testGit.CurrentTag()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "v0.0.3", tag.Name)
+}
+
 func TestCurrentTagUnhappy(t *testing.T) {
 	repo := setupRepo()
 	createTestHistory(repo)

--- a/pkg/get_tags.go
+++ b/pkg/get_tags.go
@@ -45,7 +45,7 @@ func (g *Git) getTags() ([]*Tag, error) {
 	}
 
 	err = tagObjects.ForEach(func(tag *object.Tag) error {
-		tags = append(tags, &Tag{Name: tag.Name, Date: tag.Tagger.When, Hash: tag.Hash})
+		tags = append(tags, &Tag{Name: tag.Name, Date: tag.Tagger.When, Hash: tag.Target})
 
 		return nil
 	})


### PR DESCRIPTION
- annotated tags have their own hash and a target hash, for the purpose of checking if current commit is on a tag we need to check against the Target hash