### PR TITLE
fix: use correct linter

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: Commitsar check
-        uses: docker://outillage/commitsar
+        uses: docker://aevea/commitsar
   golangci-lint:
     name: runner / golangci-lint
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,6 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
       - name: Release Notary
-        uses: docker://outillage/release-notary
+        uses: docker://aevea/release-notary
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update Docker image sources for Commitsar and Release Notary in GitHub Actions workflows.
> 
>   - **Workflows**:
>     - In `linters.yml`, change Commitsar Docker image from `outillage/commitsar` to `aevea/commitsar`.
>     - In `release.yml`, change Release Notary Docker image from `outillage/release-notary` to `aevea/release-notary`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=aevea%2Fgit&utm_source=github&utm_medium=referral)<sup> for 784f6749a7b3a0d606fd4085c2635aba2be61333. You can [customize](https://app.ellipsis.dev/aevea/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->